### PR TITLE
Small change request, make function open

### DIFF
--- a/speedviewlib/src/main/java/com/github/anastr/speedviewlib/Gauge.kt
+++ b/speedviewlib/src/main/java/com/github/anastr/speedviewlib/Gauge.kt
@@ -481,7 +481,7 @@ abstract class Gauge constructor(
      * Speed-unit text position and size.
      * @return speed-unit's rect.
      */
-    protected fun getSpeedUnitTextBounds(): RectF {
+    protected open fun getSpeedUnitTextBounds(): RectF {
         val left = widthPa * speedTextPosition.x - translatedDx + padding -
                 getSpeedUnitTextWidth() * speedTextPosition.width + speedTextPadding * speedTextPosition.paddingH
         val top = heightPa * speedTextPosition.y - translatedDy + padding -


### PR DESCRIPTION
Kotlin has this feature where protected functions can't be overridden without being marked as open. I am maintaining a fork just to open this function. I am trying to move the text up slightly to put an icon below it. The easiest way to do this was to override this function.

The example for how I'm using this is here: https://github.com/agronick/aa-torque/blob/master/app/src/main/java/com/aatorque/stats/TorqueSpeedometer.kt