### PR TITLE
Allow customizing the position of ray start speed

### DIFF
--- a/speedviewlib/src/main/java/com/github/anastr/speedviewlib/RaySpeedometer.kt
+++ b/speedviewlib/src/main/java/com/github/anastr/speedviewlib/RaySpeedometer.kt
@@ -144,22 +144,27 @@ open class RaySpeedometer @JvmOverloads constructor(
 
         canvas.save()
         canvas.rotate(getStartDegree() + 90f, size * .5f, size * .5f)
-        var i = getStartDegree()
-        while (i < getEndDegree()) {
-            if (degree <= i) {
+        val zeroDegree = getDegreeAtSpeed(0f)
+        val drawingBackwards = degree <= zeroDegree
+        val rangeCheck = if (drawingBackwards) {
+            degree.toInt()..zeroDegree.toInt()
+        } else {
+            zeroDegree.toInt()..degree.toInt()
+        }
+
+        for (i in getStartDegree()..getEndDegree() step degreeBetweenMark) {
+            if (!rangeCheck.contains(i)) {
                 rayMarkPaint.color = markColor
                 canvas.drawPath(markPath, rayMarkPaint)
                 canvas.rotate(degreeBetweenMark.toFloat(), size * .5f, size * .5f)
-                i += degreeBetweenMark
-                continue
+            } else {
+                if (currentSection != null)
+                    activeMarkPaint.color = currentSection!!.color
+                else
+                    activeMarkPaint.color = 0 // transparent color
+                canvas.drawPath(markPath, activeMarkPaint)
+                canvas.rotate(degreeBetweenMark.toFloat(), size * .5f, size / 2f)
             }
-            if (currentSection != null)
-                activeMarkPaint.color = currentSection!!.color
-            else
-                activeMarkPaint.color = 0 // transparent color
-            canvas.drawPath(markPath, activeMarkPaint)
-            canvas.rotate(degreeBetweenMark.toFloat(), size * .5f, size / 2f)
-            i += degreeBetweenMark
         }
         canvas.restore()
 

--- a/speedviewlib/src/main/res/values/attrs.xml
+++ b/speedviewlib/src/main/res/values/attrs.xml
@@ -148,6 +148,7 @@
         <attr name="sv_rayColor" format="color"/>
         <attr name="sv_degreeBetweenMark" format="integer"/>
         <attr name="sv_rayMarkWidth" format="dimension"/>
+        <attr name="sv_rayStartSpeed" format="float" />
     </declare-styleable>
 
     <declare-styleable name="PointerSpeedometer" parent="Speedometer">


### PR DESCRIPTION
One of my users had commented that they [didn't like](https://github.com/agronick/aa-torque/discussions/79) that the ray speedometer drew from the beginning of the gauge instead of at 0. This looked strange especially when it was an arbitrary negative number. I added an option to set a start value. I left the current functionality but you can now set `app:sv_rayStartSpeed="0"` to draw from 0 and it will draw backwards if the value is less than 0.

You can see how it looks when starting from 0 instead of the minimum value.
![Ray start - Made with Clipchamp](https://github.com/anastr/SpeedView/assets/2042303/83575f45-dc35-4b81-8eaf-fa8f91ff13c0)
